### PR TITLE
quit with Ctrl+D

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -240,7 +240,11 @@ proc runForever() =
     while true:
         # Read line
         try:
-            currentExpression = readLineFromStdin(getPromptSymbol()).strip
+            let result = readLineFromStdin(getPromptSymbol(), currentExpression)
+            if not result:
+                raise newException(EOFError, "Ctrl+D was pressed")
+        except EOFError:
+            cleanExit()
         except IOError:
             bufferRestoreValidCode()
             indentLevel = 0


### PR DESCRIPTION
It's a common thing in a REPL that you can quit with Ctrl+D. This PR adds this functionality. I could only try it under Linux.