### PR TITLE
Ctrl+d quits the app

### DIFF
--- a/inim.nimble
+++ b/inim.nimble
@@ -11,3 +11,4 @@ bin           = @["inim"]
 
 requires "nim >= 1.0.0"
 requires "cligen >= 0.9.15"
+requires "noise"

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -1,7 +1,8 @@
 # MIT License
 # Copyright (c) 2018 Andrei Regiani
 
-import os, osproc, rdstdin, strformat, strutils, terminal, times, strformat
+import os, osproc, strformat, strutils, terminal, times, strformat, streams
+import noise
 
 type App = ref object
     nim: string
@@ -16,12 +17,12 @@ const
     IndentSpaces = "    "
     # endsWith
     IndentTriggers = [
-        ",", "=", ":", 
+        ",", "=", ":",
         "var", "let", "const", "type", "import",
         "object", "RootObj", "enum"
     ]
     # preloaded code into user's session
-    EmbeddedCode = staticRead("inimpkg/embedded.nim") 
+    EmbeddedCode = staticRead("inimpkg/embedded.nim")
 
 let
     uniquePrefix = epochTime().int
@@ -30,10 +31,12 @@ let
 proc compileCode(): auto =
     # PENDING https://github.com/nim-lang/Nim/issues/8312, remove redundant `--hint[source]=off`
     let compileCmd = [
-        app.nim, "compile", "--run", "--verbosity=0", app.flags, 
+        app.nim, "compile", "--run", "--verbosity=0", app.flags,
         "--hints=off", "--hint[source]=off", "--path=./", bufferSource
     ].join(" ")
     result = execCmdEx(compileCmd)
+
+proc getPromptSymbol(): Styler
 
 var
     currentExpression = "" # Last stdin to evaluate
@@ -43,6 +46,16 @@ var
     indentLevel = 0        # Current
     previouslyIndented = false # Helper for showError(), indentLevel resets before showError()
     buffer: File
+    noiser = Noise.init()
+
+when promptHistory:
+    # When prompt history is enabled, we want to load history
+    # TODO: Config to allow per-session history
+    var historyFile =  getConfigDir() / "inim"
+    discard existsorCreateDir(historyFile)
+    historyFile = historyFile / ".history"
+    discard noiser.historyLoad(historyFile)
+
 
 proc getNimVersion*(): string =
     let (output, status) = execCmdEx(fmt"{app.nim} --version")
@@ -76,10 +89,10 @@ proc cleanExit(exitCode = 0) =
     removeFile(bufferSource) # Temp .nim
     removeFile(bufferSource[0..^5]) # Temp binary, same filename just without ".nim"
     removeDir(getTempDir() & "nimcache")
+    when promptHistory:
+        # Save our history
+        discard noiser.historySave(historyFile)
     quit(exitCode)
-
-proc controlCHook() {.noconv.} =
-    cleanExit(1)
 
 proc getFileData(path: string): string =
     try: path.readFile() except: ""
@@ -203,8 +216,27 @@ proc showError(output: string) =
         stdout.flushFile()
         previouslyIndented = false
 
+proc getPromptSymbol(): Styler =
+    var prompt = ""
+    if indentLevel == 0:
+        prompt = "nim> "
+        previouslyIndented = false
+    else:
+        prompt =  ".... "
+    # Auto-indent (multi-level)
+    prompt &= IndentSpaces.repeat(indentLevel)
+    result = Styler.init(prompt)
+
+proc hasIndentTrigger*(line: string): bool =
+    if line.len > 0:
+        for trigger in IndentTriggers:
+            if line.strip().endsWith(trigger):
+                result = true
+
 proc init(preload = "") =
-    setControlCHook(controlCHook)
+    let prompt = getPromptSymbol()
+
+    noiser.setPrompt(prompt)
     bufferRestoreValidCode()
 
     if preload == "":
@@ -228,15 +260,6 @@ proc init(preload = "") =
         showError(output)
         cleanExit(1)
 
-proc getPromptSymbol(): string =
-    if indentLevel == 0:
-        result = "nim> "
-        previouslyIndented = false
-    else:
-        result = ".... "
-    # Auto-indent (multi-level)
-    result &= IndentSpaces.repeat(indentLevel)
-
 proc hasIndentTrigger*(line: string): bool =
     if line.len == 0:
         return
@@ -246,13 +269,21 @@ proc hasIndentTrigger*(line: string): bool =
 
 proc doRepl() =
     # Read line
-    try:
-        currentExpression = readLineFromStdin(getPromptSymbol()).strip
-    except IOError:
-        bufferRestoreValidCode()
-        indentLevel = 0
-        tempIndentCode = ""
-        return
+    let ok = noiser.readLine()
+    if not ok:
+        case noiser.getKeyType():
+        of ktCtrlC:
+            bufferRestoreValidCode()
+            indentLevel = 0
+            tempIndentCode = ""
+            continue
+        of ktCtrlD:
+            echo "\nQuitting INim: Goodbye!"
+            cleanExit()
+        else:
+            continue
+
+    currentExpression = noiser.getLine
 
     # Special commands
     if currentExpression in ["exit", "exit()", "quit", "quit()"]:
@@ -280,10 +311,18 @@ proc doRepl() =
         let n = if currentExpression.hasIndentTrigger(): 1 else: 0
         tempIndentCode &= IndentSpaces.repeat(indentLevel-n) &
             currentExpression & "\n"
+        when promptHistory:
+            # Add in indents to our history
+            if tempIndentCode.len > 0:
+                noiser.historyAdd(IndentSpaces.repeat(indentLevel-n) & currentExpression)
         return
 
     # Compile buffer
     let (output, status) = compileCode()
+
+    when promptHistory:
+        if currentExpression.len > 0:
+            noiser.historyAdd(currentExpression)
 
     # Succesful compilation, expression is valid
     if status == 0:
@@ -341,9 +380,10 @@ proc main(nim = "nim", srcFile = "", showHeader = true, flags: seq[string] = @[]
         init(fileData) # Preload code into init
     else:
         init() # Clean init
-    
+
     while true:
         doRepl()
+
 
 when isMainModule:
     import cligen

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -227,16 +227,7 @@ proc getPromptSymbol(): Styler =
     prompt &= IndentSpaces.repeat(indentLevel)
     result = Styler.init(prompt)
 
-proc hasIndentTrigger*(line: string): bool =
-    if line.len > 0:
-        for trigger in IndentTriggers:
-            if line.strip().endsWith(trigger):
-                result = true
-
 proc init(preload = "") =
-    let prompt = getPromptSymbol()
-
-    noiser.setPrompt(prompt)
     bufferRestoreValidCode()
 
     if preload == "":
@@ -276,12 +267,12 @@ proc doRepl() =
             bufferRestoreValidCode()
             indentLevel = 0
             tempIndentCode = ""
-            continue
+            return
         of ktCtrlD:
             echo "\nQuitting INim: Goodbye!"
             cleanExit()
         else:
-            continue
+            return
 
     currentExpression = noiser.getLine
 
@@ -382,8 +373,10 @@ proc main(nim = "nim", srcFile = "", showHeader = true, flags: seq[string] = @[]
         init() # Clean init
 
     while true:
-        doRepl()
+        let prompt = getPromptSymbol()
+        noiser.setPrompt(prompt)
 
+        doRepl()
 
 when isMainModule:
     import cligen


### PR DESCRIPTION
So, this feels like it could be simplified down a lot more. Essentially, this patches linenoise so that it returns a signal when it processed a CTRL-D instead of the default linenoise behaviour (which is delete the last character OR EOF). 

Considerations:
- Can we limit the code duplication, rather than copying in everything?
- Can we monkey patch just the readLineFromStdin directly in inim.nim, rather than use a proxy rdstdin implementation?
- Better way to indicate a SIGQUIT signal than a string literal?