### PR TITLE
Codestyling changes, fix discarded "1+1" output

### DIFF
--- a/inim.nimble
+++ b/inim.nimble
@@ -9,5 +9,5 @@ bin           = @["inim"]
 
 # Dependencies
 
-requires "nim >= 0.17.0"
+requires "nim >= 1.0.0"
 requires "cligen >= 0.9.15"

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -4,351 +4,355 @@
 import os, osproc, rdstdin, strformat, strutils, terminal, times, strformat
 
 type App = ref object
-    nim: string
-    srcFile: string
-    showHeader: bool
-    flags: string
+  nim: string
+  srcFile: string
+  showHeader: bool
+  flags: string
 
 var app: App
 
 const
-    INimVersion = "0.4.3"
-    indentSpaces = "    "
-    indentTriggers = [",", "=", ":", "var", "let", "const", "type", "import",
-                      "object", "RootObj", "enum"] # endsWith
-    embeddedCode = staticRead("inimpkg/embedded.nim") # preloaded code into user's session
+  INimVersion = "0.4.3"
+  IndentSpaces = "    "
+  # endsWith
+  IndentTriggers = [
+    ",", "=", ":",
+    "var", "let", "const", "type", "import",
+    "object", "RootObj", "enum"
+  ]
+  # preloaded code into user's session
+  EmbeddedCode = staticRead("inimpkg/embedded.nim")
 
 let
-    uniquePrefix = epochTime().int
-    bufferSource = getTempDir() & "inim_" & $uniquePrefix & ".nim"
+  uniquePrefix = epochTime().int
+  bufferSource = fmt"{getTempDir()}inim_{uniquePrefix}.nim"
 
-proc compileCode(): auto =
-    # PENDING https://github.com/nim-lang/Nim/issues/8312, remove redundant `--hint[source]=off`
-    let compileCmd = fmt"{app.nim} compile --run --verbosity=0{app.flags} --hints=off --hint[source]=off --path=./ {bufferSource}"
-    result = execCmdEx(compileCmd)
+proc compileCode(): (string, int) =
+  # PENDING https://github.com/nim-lang/Nim/issues/8312, remove redundant `--hint[source]=off`
+  let compileCmd = [
+    app.nim, "compile", "--run", "--verbosity=0", app.flags,
+    "--hints=off", "--hint[source]=off", "--path=/.", bufferSource
+  ].join(" ")
+  result = execCmdEx(compileCmd)
 
 var
-    currentExpression = "" # Last stdin to evaluate
-    currentOutputLine = 0  # Last line shown from buffer's stdout
-    validCode = ""         # All statements compiled succesfully
-    tempIndentCode = ""    # Later append to `validCode` if whole block compiles well
-    indentLevel = 0        # Current
-    previouslyIndented = false # Helper for showError(), indentLevel resets before showError()
-    buffer: File
+  currentExpression = "" # Last stdin to evaluate
+  currentOutputLine = 0  # Last line shown from buffer's stdout
+  validCode = ""         # All statements compiled succesfully
+  tempIndentCode = ""    # Later append to `validCode` if whole block compiles well
+  indentLevel = 0        # Current
+  previouslyIndented = false # Helper for showError(), indentLevel resets before showError()
+  buffer: File
 
 proc getNimVersion*(): string =
-    let (output, status) = execCmdEx(fmt"{app.nim} --version")
-    doAssert status == 0, fmt"make sure {app.nim} is in PATH"
-    result = output.splitLines()[0]
+  let (output, status) = execCmdEx(fmt"{app.nim} --version")
+  doAssert status == 0, fmt"make sure {app.nim} is in PATH"
+  result = output.splitLines()[0]
 
 proc getNimPath(): string =
-    # TODO: use `which` PENDING https://github.com/nim-lang/Nim/issues/8311
-    when defined(Windows):
-        let which_cmd = fmt"where {app.nim}"
-    else:
-        let which_cmd = fmt"which {app.nim}"
-    let (output, status) = execCmdEx(which_cmd)
-    if status == 0:
-        return " at " & output
-    return "\n"
+  # TODO: use `which` PENDING https://github.com/nim-lang/Nim/issues/8311
+  let whichCmd = when defined(Windows):
+    fmt"where {app.nim}"
+  else:
+    fmt"which {app.nim}"
+  let (output, status) = execCmdEx(whichCmd)
+  if status == 0:
+    return " at " & output
+  return "\n"
 
 proc welcomeScreen() =
-    stdout.setForegroundColor(fgYellow)
-    when defined(posix):
-        stdout.write "👑 " # Crashes on Windows: Unknown IO Error [IOError]
-    stdout.writeLine "INim ", INimVersion
-    stdout.setForegroundColor(fgCyan)
-    stdout.write getNimVersion()
-    stdout.write getNimPath()
-    stdout.resetAttributes()
-    stdout.flushFile()
+  stdout.setForegroundColor(fgYellow)
+  when defined(posix):
+    stdout.write "👑 " # Crashes on Windows: Unknown IO Error [IOError]
+  stdout.writeLine "INim ", INimVersion
+  stdout.setForegroundColor(fgCyan)
+  stdout.write getNimVersion()
+  stdout.write getNimPath()
+  stdout.resetAttributes()
+  stdout.flushFile()
 
 proc cleanExit(exitCode = 0) =
-    buffer.close()
-    removeFile(bufferSource) # Temp .nim
-    removeFile(bufferSource[0..^5]) # Temp binary, same filename just without ".nim"
-    removeDir(getTempDir() & "nimcache")
-    quit(exitCode)
+  buffer.close()
+  removeFile(bufferSource) # Temp .nim
+  removeFile(bufferSource[0..^5]) # Temp binary, same filename just without ".nim"
+  removeDir(getTempDir() & "nimcache")
+  quit(exitCode)
 
 proc controlCHook() {.noconv.} =
-    cleanExit(1)
+  cleanExit(1)
 
 proc getFileData(path: string): string =
-    try:
-        result = path.readFile()
-    except:
-        result = ""
+  try: path.readFile() except: ""
 
-proc compilationSuccess(current_statement, output: string) =
-    if len(tempIndentCode) > 0:
-        validCode &= tempIndentCode
-    else:
-        validCode &= current_statement & "\n"
+proc compilationSuccess(currentStmt, output: string) =
+  if len(tempIndentCode) > 0:
+    validCode &= tempIndentCode
+  else:
+    validCode &= currentStmt & "\n"
 
-    # Print only output you haven't seen
-    stdout.setForegroundColor(fgCyan, true)
-    let lines = output.splitLines
-    let new_lines = lines[currentOutputLine..^1]
-    for index, line in new_lines:
-        # Skip last empty line (otherwise blank line is displayed after command)
-        if index+1 == len(new_lines) and line == "":
-            continue
-        echo line
+  # Print only output you haven't seen
+  stdout.setForegroundColor(fgCyan, true)
+  let lines = output.splitLines
+  let new_lines = lines[currentOutputLine..^1]
+  for index, line in new_lines:
+    # Skip last empty line (otherwise blank line is displayed after command)
+    if index+1 == len(new_lines) and line == "":
+      continue
+    echo line
 
-    currentOutputLine = len(lines)-1
-    stdout.resetAttributes()
-    stdout.flushFile()
+  currentOutputLine = len(lines)-1
+  stdout.resetAttributes()
+  stdout.flushFile()
 
 proc bufferRestoreValidCode() =
-    if buffer != nil:
-        buffer.close()
-    buffer = open(bufferSource, fmWrite)
-    buffer.writeLine(embeddedCode)
-    buffer.write(validCode)
-    buffer.flushFile()
+  if buffer != nil:
+    buffer.close()
+  buffer = open(bufferSource, fmWrite)
+  buffer.writeLine(EmbeddedCode)
+  buffer.write(validCode)
+  buffer.flushFile()
 
 proc showError(output: string) =
-    # Determine whether last expression was to import a module
-    var importStatement = false
-    try:
-        if currentExpression[0..6] == "import ":
-            importStatement = true
-    except IndexError:
-        discard
+  # Determine whether last expression was to import a module
+  var importStatement = false
+  try:
+    if currentExpression[0..6] == "import ":
+      importStatement = true
+  except IndexError:
+    discard
 
-    #### Runtime errors:
-    if output.contains("Error: unhandled exception:"):
-        stdout.setForegroundColor(fgRed, true)
-        # Display only the relevant lines of the stack trace
-        let lines = output.splitLines()
+  #### Runtime errors:
+  if output.contains("Error: unhandled exception:"):
+    stdout.setForegroundColor(fgRed, true)
+    # Display only the relevant lines of the stack trace
+    let lines = output.splitLines()
 
-        if not importStatement:
-            echo lines[^3]
-        else:
-            for line in lines[len(lines)-5 .. len(lines)-3]:
-                echo line
-
-        stdout.resetAttributes()
-        stdout.flushFile()
-        return
-
-    #### Compilation errors:
-    # Prints only relevant message without file and line number info.
-    # e.g. "inim_1520787258.nim(2, 6) Error: undeclared identifier: 'foo'"
-    # Becomes: "Error: undeclared identifier: 'foo'"
-    let pos = output.find(")") + 2
-    var message = output[pos..^1].strip
-
-    # Discard shortcut conditions
-    let
-        a = currentExpression != ""
-        b = importStatement == false
-        c = previouslyIndented == false
-        d = message.endsWith("discarded")
-
-    # Discarded shortcut, print values: nim> myvar
-    if a and b and c and d:
-        # Following lines grabs the type from the discarded expression:
-        # Remove text bloat to result into: e.g. foo'int
-        message = message.replace("Error: expression '")
-        message = message.replace(" is of type '")
-        message = message.replace("' and has to be discarded")
-        # Make split char to be a semicolon instead of a single-quote,
-        # To avoid char type conflict having single-quotes
-        message[message.rfind("'")] = ';' # last single-quote
-        let message_seq = message.split(";") # expression;type, e.g 'a';char
-        let typeExpression = message_seq[1]                 # type, e.g. char
-
-        var shortcut: string
-        when defined(Windows):
-            shortcut = fmt"""
-            stdout.write $({currentExpression})
-            stdout.write "  : "
-            stdout.write "{typeExpression}"
-            echo ""
-            """.replace("            ", "")
-        else: # Posix: colorize type to yellow
-            shortcut = fmt"""
-            stdout.write $({currentExpression})
-            stdout.write "\e[33m" # Yellow
-            stdout.write "  : "
-            stdout.write "{typeExpression}"
-            echo "\e[39m" # Reset color
-            """.replace("            ", "")
-
-        buffer.writeLine(shortcut)
-        buffer.flushFile()
-
-        let (output, status) = compileCode()
-        if status == 0:
-            compilationSuccess(shortcut, output)
-        else:
-            bufferRestoreValidCode()
-            showError(output) # Recursion
-
-    # Display all other errors
+    if not importStatement:
+      echo lines[^3]
     else:
-        stdout.setForegroundColor(fgRed, true)
-        if importStatement:
-            echo output.strip() # Full message
-        else:
-            echo message # Shortened message
-        stdout.resetAttributes()
-        stdout.flushFile()
-        previouslyIndented = false
+      for line in lines[len(lines)-5 .. len(lines)-3]:
+        echo line
 
-proc init(preload = "") =
-    setControlCHook(controlCHook)
-    bufferRestoreValidCode()
+    stdout.resetAttributes()
+    stdout.flushFile()
+    return
 
-    if preload == "":
-        # First dummy compilation so next one is faster for the user
-        discard compileCode()
-        return
+  #### Compilation errors:
+  # Prints only relevant message without file and line number info.
+  # e.g. "inim_1520787258.nim(2, 6) Error: undeclared identifier: 'foo'"
+  # Becomes: "Error: undeclared identifier: 'foo'"
+  let pos = output.find(")") + 2
+  var message = output[pos..^1].strip
 
-    buffer.writeLine(preload)
+  # Discard shortcut conditions
+  let
+    a = currentExpression != ""
+    b = importStatement == false
+    c = previouslyIndented == false
+    d = message.endsWith("discarded")
+
+  # Discarded shortcut, print values: nim> myvar
+  if a and b and c and d:
+    # Following lines grabs the type from the discarded expression:
+    # Remove text bloat to result into: e.g. foo'int
+    message = message.multiReplace({
+      "Error: expression '": "",
+      " is of type '": "",
+      "' and has to be discarded": ""
+    })
+    # Make split char to be a semicolon instead of a single-quote,
+    # To avoid char type conflict having single-quotes
+    message[message.rfind("'")] = ';' # last single-quote
+    let message_seq = message.split(";") # expression;type, e.g 'a';char
+    let typeExpression = message_seq[1] # type, e.g. char
+
+    let shortcut = when defined(Windows):
+      fmt"""
+      stdout.write $({currentExpression})
+      stdout.write "  : "
+      stdout.write "{typeExpression}"
+      echo ""
+      """.unindent()
+    else: # Posix: colorize type to yellow
+      fmt"""
+      stdout.write $({currentExpression})
+      stdout.write "\e[33m" # Yellow
+      stdout.write "  : "
+      stdout.write "{typeExpression}"
+      echo "\e[39m" # Reset color
+      """.unindent()
+
+    buffer.writeLine(shortcut)
     buffer.flushFile()
 
-    # Check preloaded file compiles succesfully
     let (output, status) = compileCode()
     if status == 0:
-        compilationSuccess(preload, output)
-
-    # Compilation error
+      compilationSuccess(shortcut, output)
     else:
-        bufferRestoreValidCode()
-        # Imports display more of the stack trace in case of errors, instead of one liners error
-        currentExpression = "import " # Pretend it was an import for showError()
-        showError(output)
-        cleanExit(1)
+      bufferRestoreValidCode()
+      showError(output) # Recursion
+
+  # Display all other errors
+  else:
+    stdout.setForegroundColor(fgRed, true)
+    if importStatement:
+      echo output.strip() # Full message
+    else:
+      echo message # Shortened message
+    stdout.resetAttributes()
+    stdout.flushFile()
+    previouslyIndented = false
+
+proc init(preload = "") =
+  setControlCHook(controlCHook)
+  bufferRestoreValidCode()
+
+  if preload == "":
+    # First dummy compilation so next one is faster for the user
+    discard compileCode()
+    return
+
+  buffer.writeLine(preload)
+  buffer.flushFile()
+
+  # Check preloaded file compiles succesfully
+  let (output, status) = compileCode()
+  if status == 0:
+    compilationSuccess(preload, output)
+
+  # Compilation error
+  else:
+    bufferRestoreValidCode()
+    # Imports display more of the stack trace in case of errors, instead of one liners error
+    currentExpression = "import " # Pretend it was an import for showError()
+    showError(output)
+    cleanExit(1)
 
 proc getPromptSymbol(): string =
-    if indentLevel == 0:
-        result = "nim> "
-        previouslyIndented = false
-    else:
-        result = ".... "
-    # Auto-indent (multi-level)
-    result &= indentSpaces.repeat(indentLevel)
+  if indentLevel == 0:
+    result = "nim> "
+    previouslyIndented = false
+  else:
+    result = ".... "
+  # Auto-indent (multi-level)
+  result &= IndentSpaces.repeat(indentLevel)
 
 proc hasIndentTrigger*(line: string): bool =
-    if line.len > 0:
-        for trigger in indentTriggers:
-            if line.strip().endsWith(trigger):
-                result = true
+  if line.len == 0:
+    return
+  for trigger in IndentTriggers:
+    if line.strip().endsWith(trigger):
+      result = true
 
-proc runForever() =
-    while true:
-        # Read line
-        try:
-            currentExpression = readLineFromStdin(getPromptSymbol()).strip
-        except IOError:
-            bufferRestoreValidCode()
-            indentLevel = 0
-            tempIndentCode = ""
-            continue
+proc doRepl() =
+  # Read line
+  try:
+    currentExpression = readLineFromStdin(getPromptSymbol()).strip
+  except IOError:
+    bufferRestoreValidCode()
+    indentLevel = 0
+    tempIndentCode = ""
+    return
 
-        # Special commands
-        if currentExpression in ["exit", "exit()", "quit", "quit()"]:
-            cleanExit()
+  # Special commands
+  if currentExpression in ["exit", "exit()", "quit", "quit()"]:
+    cleanExit()
 
-        # Empty line: exit indent level, otherwise do nothing
-        if currentExpression == "":
-            if indentLevel > 0:
-                indentLevel -= 1
-            elif indentLevel == 0:
-                continue
+  # Empty line: exit indent level, otherwise do nothing
+  if currentExpression == "":
+    if indentLevel > 0:
+      indentLevel -= 1
+    elif indentLevel == 0:
+      return
 
-        # Write your line to buffer(temp) source code
-        buffer.writeLine(indentSpaces.repeat(indentLevel) & currentExpression)
-        buffer.flushFile()
+  # Write your line to buffer(temp) source code
+  buffer.writeLine(IndentSpaces.repeat(indentLevel) & currentExpression)
+  buffer.flushFile()
 
-        # Check for indent and trigger it
-        if currentExpression.hasIndentTrigger():
-            indentLevel += 1
-            previouslyIndented = true
+  # Check for indent and trigger it
+  if currentExpression.hasIndentTrigger():
+    indentLevel += 1
+    previouslyIndented = true
 
-        # Don't run yet if still on indent
-        if indentLevel != 0:
-            # Skip indent for first line
-            if currentExpression.hasIndentTrigger():
-                tempIndentCode &= indentSpaces.repeat(indentLevel-1) &
-                        currentExpression & "\n"
-            else:
-                tempIndentCode &= indentSpaces.repeat(indentLevel) &
-                        currentExpression & "\n"
-            continue
+  # Don't run yet if still on indent
+  if indentLevel != 0:
+    # Skip indent for first line
+    let n = if currentExpression.hasIndentTrigger(): -1 else: 0
+    tempIndentCode &= IndentSpaces.repeat(indentLevel-n) &
+      currentExpression & "\n"
+    return
 
-        # Compile buffer
-        let (output, status) = compileCode()
+  # Compile buffer
+  let (output, status) = compileCode()
 
-        # Succesful compilation, expression is valid
-        if status == 0:
-            compilationSuccess(currentExpression, output)
-        # Maybe trying to echo value?
-        elif "has to be discarded" in output and indentLevel == 0: #
-            bufferRestoreValidCode()
+  # Succesful compilation, expression is valid
+  if status == 0:
+    compilationSuccess(currentExpression, output)
+  # Maybe trying to echo value?
+  elif "has to be discarded" in output and indentLevel == 0:
+    bufferRestoreValidCode()
 
-            # Save the current expression as an echo
-            currentExpression = "echo $" & currentExpression
-            buffer.writeLine(currentExpression)
-            buffer.flushFile()
+    # Save the current expression as an echo
+    currentExpression = fmt"echo $({currentExpression})"
+    buffer.writeLine(currentExpression)
+    buffer.flushFile()
 
-            let (echo_output, echo_status) = compileCode()
-            if echo_status == 0:
-                compilationSuccess(currentExpression, echo_output)
-            else:
-                # Show any errors in echoing the statement
-                indentLevel = 0
-                showError(echo_output)
-            # Roll back to not include the temporary echo line
-            bufferRestoreValidCode()
-        # Compilation error
-        else:
-            # Write back valid code to buffer
-            bufferRestoreValidCode()
-            indentLevel = 0
-            showError(output)
+    let (echo_output, echo_status) = compileCode()
+    if echo_status == 0:
+      compilationSuccess(currentExpression, echo_output)
+    else:
+      # Show any errors in echoing the statement
+      indentLevel = 0
+      showError(echo_output)
+    # Roll back to not include the temporary echo line
+    bufferRestoreValidCode()
+  # Compilation error
+  else:
+    # Write back valid code to buffer
+    bufferRestoreValidCode()
+    indentLevel = 0
+    showError(output)
 
-        # Clean up
-        tempIndentCode = ""
+  # Clean up
+  tempIndentCode = ""
 
 proc initApp*() =
-    ## Initialize the ``app` variable.
-    app.new()
-    app.nim = "nim"
-    app.srcFile = ""
-    app.showHeader = true
+  ## Initialize the ``app` variable.
+  app = App(
+    nim: "nim",
+    srcFile: "",
+    showHeader: true,
+    flags: ""
+  )
 
 proc main(nim = "nim", srcFile = "", showHeader = true, flags: seq[string] = @[]) =
-    ## inim interpreter
+  ## inim interpreter
 
-    initApp()
-    app.nim = nim
-    app.srcFile = srcFile
-    app.showHeader = showHeader
-    if flags.len > 0:
-        app.flags = " -d:" & join(@flags, " -d:")
-    else:
-        app.flags = ""
+  initApp()
+  app.nim = nim
+  app.srcFile = srcFile
+  app.showHeader = showHeader
+  if flags.len > 0:
+    app.flags = " -d:" & join(@flags, " -d:")
 
-    if app.showHeader: welcomeScreen()
+  if app.showHeader: welcomeScreen()
 
-    if srcFile.len > 0:
-        doAssert(srcFile.fileExists, "cannot access " & srcFile)
-        doAssert(srcFile.splitFile.ext == ".nim")
-        let fileData = getFileData(srcFile)
-        init(fileData) # Preload code into init
-    else:
-        init() # Clean init
+  if srcFile.len > 0:
+    doAssert(srcFile.fileExists, "cannot access " & srcFile)
+    doAssert(srcFile.splitFile.ext == ".nim")
+    let fileData = getFileData(srcFile)
+    init(fileData) # Preload code into init
+  else:
+    init() # Clean init
 
-    runForever()
+  while true:
+    doRepl()
 
 when isMainModule:
-    import cligen
-    dispatch(main, short = {"flags": 'd'}, help = {
-            "nim": "path to nim compiler",
-            "srcFile": "nim script to preload/run",
-            "showHeader": "show program info startup",
-            "flags": "nim flags to pass to the compiler"
-        })
+  import cligen
+  dispatch(main, short = {"flags": 'd'}, help = {
+      "nim": "path to nim compiler",
+      "srcFile": "nim script to preload/run",
+      "showHeader": "show program info startup",
+      "flags": "nim flags to pass to the compiler"
+    })


### PR DESCRIPTION
So changes I did here:
- Use 2-space indent instead of 4-space (maybe it's just preference, but it seems to me that this way code is "nicer" to look at)
- Use less indentation where possible (mostly I did that by moving `while true` out of `runForever` - renamed to `doRepl` procedure, and replaced "continue" with "return" since in this case they would do the same), also in `hasIndentTrigger`
- Fixed an error when code like `1+1` or `1+2-3` would error because INim made code like `echo $1+2-3` instead of `echo $(1+2-3)` in this PR
- Use if expressions in some places to simplify code a bit
- Up Nim version in .nimble file to `1.0.0`
- Rename constants to PascalCase
- Try to make less than 80 characters in most lines
- Used `multiReplace` instead of 3 different replaces (I'm also thinking of replacing this whole error parsing logic with `strscans` module which will look nicer)
- Used `unindent` instead of `replace` with 8 spaces which does the same and is agnostic to the number of indentation at the start of the line.

I may have introduced some new bugs/errors even if I didn't really modify any logic, so please comment if you find something.