### PR TITLE
Print value type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Config is saved and loaded from `configDir / inim`.
 
 Currently, the config allows you to set two options:
 * Style
-  * Set prompt string (default: "inim> ")
+  * `prompt`: Set prompt string (default: "inim> ")
+  * `showTypes`: Show var types when printing without echo (default: true)
 * History
   * persistent history (default: true)
 

--- a/src/inimpkg/embedded.nim
+++ b/src/inimpkg/embedded.nim
@@ -1,2 +1,4 @@
 ## INim/src/embedded.nim: preloaded into user's REPL session
 ## ---------------------------------------------------------
+{. warning[UnusedImport]:off .}
+import typetraits


### PR DESCRIPTION
Added a config flag for this and made it only echo when we're printing a var without a preceding `echo` (so people can actually put normal echo calls into the repl without extra side effects) 