### PR TITLE
Compatibility with devel (and future 1.4 release)

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -190,7 +190,6 @@ proc showError(output: string) =
         " is of type '": "",
         "' and has to be discarded": "",
         "' and has to be used (or discarded)": ""
-
     })
     # Make split char to be a semicolon instead of a single-quote,
     # To avoid char type conflict having single-quotes

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -179,7 +179,7 @@ proc showError(output: string) =
     a = currentExpression != ""
     b = importStatement == false
     c = previouslyIndented == false
-    d = message.endsWith("discarded")
+    d = message.contains("and has to be")
 
   # Discarded shortcut, print values: nim> myvar
   if a and b and c and d:
@@ -188,7 +188,9 @@ proc showError(output: string) =
     message = message.multiReplace({
         "Error: expression '": "",
         " is of type '": "",
-        "' and has to be discarded": ""
+        "' and has to be discarded": "",
+        "' and has to be used (or discarded)": ""
+
     })
     # Make split char to be a semicolon instead of a single-quote,
     # To avoid char type conflict having single-quotes


### PR DESCRIPTION
It was changed in https://github.com/nim-lang/Nim/commit/7f1d2489ad79d09c649e37b6d2db12f5fdbd86d7 and will be in the next 1.4 release probably (and it's already there in devel).
For backwards compatibility we should keep both versions in multiReplace