### PR TITLE
Use version string from Nimble package info

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -16,7 +16,7 @@ var
   config: Config
 
 const
-  INimVersion = "0.4.7"
+  NimblePkgVersion {.strdefine.} = "Unknown"
   IndentSpaces = "  "
   # endsWith
   IndentTriggers = [
@@ -92,7 +92,7 @@ proc welcomeScreen() =
   outputFg(fgYellow, false):
     when defined(posix):
       stdout.write "👑 " # Crashes on Windows: Unknown IO Error [IOError]
-    stdout.writeLine "INim ", INimVersion
+    stdout.writeLine "INim ", NimblePkgVersion
     stdout.setForegroundColor(fgCyan)
     stdout.write getNimVersion()
     stdout.write getNimPath()

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -16,7 +16,7 @@ var
   config: Config
 
 const
-  NimblePkgVersion {.strdefine.} = "Unknown"
+  NimblePkgVersion {.strdefine.} = ""
   IndentSpaces = "  "
   # endsWith
   IndentTriggers = [


### PR DESCRIPTION
I don't know if this is desirable, but basically with this change the version will always be from Nimble. If inim is built without Nimble the prompt wouldn't specify INim version at all.

So if this behaviour is OK - you can merge, otherwise - don't ;)

https://github.com/nim-lang/nimble/blob/master/changelog.markdown#0110---22092019 when it was added