### PR TITLE
Can use Ctrl-X to open code using $EDITOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Runs in the current directory: `import` your local modules (access to exported* symbols)
 * Preload existing source code (access to non-exported* symbols): `inim -s example.nim`
 * Optional Colorized output
+* Edit lines using $EDITOR (Ctrl-X)
 
 ## Config
 Config is saved and loaded from `configDir / inim`.

--- a/inim.nimble
+++ b/inim.nimble
@@ -11,10 +11,7 @@ bin           = @["inim"]
 
 requires "nim >= 1.0.0"
 requires "cligen >= 0.9.15"
-# TODO: Swap back to the default nimble package after https://github.com/jangko/nim-noise/pull/9 is merged
-# requires "noise"
-requires "https://github.com/Tangdongle/nim-noise"
-
+requires "noise"
 
 task test, "Run all tests":
   exec "mkdir -p bin"

--- a/inim.nimble
+++ b/inim.nimble
@@ -12,7 +12,7 @@ bin           = @["inim"]
 requires "nim >= 1.0.0"
 requires "cligen >= 0.9.15"
 # TODO: Swap back to the default nimble package after https://github.com/jangko/nim-noise/pull/9 is merged
-# requires "nim-noise"
+# requires "noise"
 requires "https://github.com/Tangdongle/nim-noise"
 
 

--- a/inim.nimble
+++ b/inim.nimble
@@ -11,7 +11,9 @@ bin           = @["inim"]
 
 requires "nim >= 1.0.0"
 requires "cligen >= 0.9.15"
-requires "noise"
+# TODO: Swap back to the default nimble package after https://github.com/jangko/nim-noise/pull/9 is merged
+# requires "nim-noise"
+requires "https://github.com/Tangdongle/nim-noise"
 
 
 task test, "Run all tests":


### PR DESCRIPTION
Added support for editing code using your environment's $EDITOR

Works, but I had to extend nim-noise to add an extra meta character (https://github.com/jangko/nim-noise/pull/9). Can wait for that to be merged and I'll revert the nimble require here: https://github.com/inim-repl/INim/compare/master...TangersTongle:editor_support?expand=1#diff-0fdaf9697c4d59b94f10d5a02de044c3R16