### PR TITLE
showColor corrected

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -38,7 +38,7 @@ proc createRcFile(path: string): Config =
   result.setSectionKey("History", "persistent", "True")
   result.setSectionKey("Style", "prompt", "nim> ")
   result.setSectionKey("Style", "showTypes", "True")
-  result.setSectionKey("Style", "ShowColor", "True")
+  result.setSectionKey("Style", "showColor", "True")
   result.writeConfig(path)
 
 let


### PR DESCRIPTION
The rc file wasn't created correctly. It contained "ShowColor" instead of "showColor", thus syntax highlighting was disabled by default.