### PR TITLE
Get rid of janky error reraising when trying to print it's type

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -470,7 +470,7 @@ call(cmd) - Execute command cmd in current shell
     else:
       # Show any errors in echoing the statement
       indentLevel = 0
-      if showTypes == "True":
+      if app.showTypes:
         # If we show types and this has errored again,
         # reraise the original error message
         showError(output, reraised = true)

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -4,6 +4,7 @@
 import os, osproc, strformat, strutils, terminal,
        times, strformat, parsecfg
 import noise
+from sequtils import filterIt
 
 # Lists available builtin commands
 var commands*: seq[string] = @[]
@@ -186,7 +187,7 @@ proc bufferRestoreValidCode() =
   buffer.write(validCode)
   buffer.flushFile()
 
-proc showError(output: string) =
+proc showError(output: string, reraised: bool = false) =
   # Determine whether last expression was to import a module
   var importStatement = false
   try:
@@ -195,11 +196,20 @@ proc showError(output: string) =
   except IndexError:
     discard
 
+  #### Reraised errors. These get reraised if the statement being echoed with a type fails
+  if reraised:
+    outputFg(fgRed, true):
+      if output.contains("Error"):
+        echo output[output.find("Error") .. ^2]
+      else:
+        echo output
+    return
+
   #### Runtime errors:
   if output.contains("Error: unhandled exception:"):
     outputFg(fgRed, true):
       # Display only the relevant lines of the stack trace
-      let lines = output.splitLines()
+      var lines = output.splitLines().filterIt(not it.isEmptyOrWhitespace)
 
       if not importStatement:
         echo lines[^3]
@@ -460,7 +470,12 @@ call(cmd) - Execute command cmd in current shell
     else:
       # Show any errors in echoing the statement
       indentLevel = 0
-      showError(echo_output)
+      if showTypes == "True":
+        # If we show types and this has errored again,
+        # reraise the original error message
+        showError(output, reraised = true)
+      else:
+        showError(echo_output)
       # Roll back to not include the temporary echo line
       bufferRestoreValidCode()
 

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -1,6 +1,6 @@
 ## TODO: Split these up
 ## Maybe see if I can store a base state of the process before each tests runs and roll back after
-import osproc, streams, os, sequtils
+import osproc, streams, os
 import unittest
 
 let

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -36,6 +36,8 @@ suite "Interface Tests":
       "a"
     ]
     require getResponse(inputStream, outputStream, defLines) == "A == type string"
+    stderr.writeLine("Checked Def Lines")
+    stderr.flushFile()
 
     let typeLines = @[
       "type B = object",
@@ -45,12 +47,16 @@ suite "Interface Tests":
     ]
     require getResponse(inputStream, outputStream, typeLines) == "B == type B"
     require getResponse(inputStream, outputStream, @["B.c"]) == "string == type string"
+    stderr.writeLine("Checked Type Lines")
+    stderr.flushFile()
 
     let varLines = @[
       """var g = B(c: "C")""",
       "g"
     ]
     require getResponse(inputStream, outputStream, varLines) == """(c: "C") == type B"""
+    stderr.writeLine("Checked Var Lines")
+    stderr.flushFile()
 
     # Make sure we're not creating more errors when we type in code that wouldn't compile normally
     let jankLines = @[
@@ -62,6 +68,8 @@ suite "Interface Tests":
       """Error: expression 'a + b' is of type 'float' and has to be used (or discarded)""",
       """Error: expression 'a + b' is of type 'float' and has to be discarded"""
     ]
+    stderr.writeLine("Checked Jank Lines")
+    stderr.flushFile()
 
     # Check indentation
     let ifLines = @[
@@ -72,6 +80,8 @@ suite "Interface Tests":
       """""",
     ]
     require getResponse(inputStream, outputStream, ifLines) == """TRUE"""
+    stderr.writeLine("Checked If Lines")
+    stderr.flushFile()
 
     inputStream.writeLine("quit")
     inputStream.flush()

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -36,8 +36,6 @@ suite "Interface Tests":
       "a"
     ]
     require getResponse(inputStream, outputStream, defLines) == "A == type string"
-    stderr.writeLine("Checked Def Lines")
-    stderr.flushFile()
 
     let typeLines = @[
       "type B = object",
@@ -47,16 +45,12 @@ suite "Interface Tests":
     ]
     require getResponse(inputStream, outputStream, typeLines) == "B == type B"
     require getResponse(inputStream, outputStream, @["B.c"]) == "string == type string"
-    stderr.writeLine("Checked Type Lines")
-    stderr.flushFile()
 
     let varLines = @[
       """var g = B(c: "C")""",
       "g"
     ]
     require getResponse(inputStream, outputStream, varLines) == """(c: "C") == type B"""
-    stderr.writeLine("Checked Var Lines")
-    stderr.flushFile()
 
     # Make sure we're not creating more errors when we type in code that wouldn't compile normally
     let jankLines = @[
@@ -68,8 +62,6 @@ suite "Interface Tests":
       """Error: expression 'a + b' is of type 'float' and has to be used (or discarded)""",
       """Error: expression 'a + b' is of type 'float' and has to be discarded"""
     ]
-    stderr.writeLine("Checked Jank Lines")
-    stderr.flushFile()
 
     # Check indentation
     let ifLines = @[
@@ -80,8 +72,6 @@ suite "Interface Tests":
       """""",
     ]
     require getResponse(inputStream, outputStream, ifLines) == """TRUE"""
-    stderr.writeLine("Checked If Lines")
-    stderr.flushFile()
 
     inputStream.writeLine("quit")
     inputStream.flush()

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -56,16 +56,14 @@ suite "Interface Tests":
     let jankLines = @[
       """proc adderNoReturnNoType(a: float, b: float) = a + b""",
     ]
+
+    # Check for both responses to work with stable vs devel of nim
     require getResponse(inputStream, outputStream, jankLines) in @[
       """Error: expression 'a + b' is of type 'float' and has to be used (or discarded)""",
       """Error: expression 'a + b' is of type 'float' and has to be discarded"""
     ]
 
-    inputStream.writeLine("quit")
-    inputStream.flush()
-    assert outputStream.atEnd()
-    process.close()
-
+    # Check indentation
     let ifLines = @[
       """if true:""",
       """  echo "TRUE"""",

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -58,6 +58,15 @@ suite "Interface Tests":
     ]
     require getResponse(inputStream, outputStream, varLines) == """(c: "C") == type B"""
 
+    # Make sure we're not creating more errors when we type in code that wouldn't compile normally
+    let jankLines = @[
+      """proc adderNoReturnNoType(a: float, b: float) = a + b""",
+    ]
+    require getResponse(inputStream, outputStream, jankLines) == """Error: expression 'a + b' is of type 'float' and has to be discarded"""
+
+    inputStream.writeLine("quit")
+    inputStream.flush()
+    assert outputStream.atEnd()
 
   test "Test commands":
     # Test cd


### PR DESCRIPTION
Fix for https://github.com/inim-repl/INim/issues/92

When printing the type for the line `proc adderNoReturnNoType(a: float, b: float) = a + b`, with showTypes enabled INim would try to print the type of the previous statement as something like `echo $(proc adderNoReturnNoType(a: float, b: float) = a + b) == $(type(proc adderNoReturnNoType(a: float, b: float) = a + b))`. 

Once this error is passed through proc showErrors to be printed, INim attempts to compile this statement and in turn hits another error. This PR prevents nested errors caused by bad type printing statements to not be re-raised, so we can output the correct error to the user. 