### PR TITLE
Add "has to be used" message for devel branch

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -203,6 +203,7 @@ proc showError(output: string) =
         "Error: expression '": "",
         " is of type '": "",
         "' and has to be used": "",
+        "' and has to be discarded": "",
         "' and has to be used (or discarded)": ""
     })
     # Make split char to be a semicolon instead of a single-quote,
@@ -389,7 +390,7 @@ Help - help, help()""")
       # Roll back echoes
       bufferRestoreValidCode()
   # Maybe trying to echo value?
-  elif "has to be used" in output and indentLevel == 0: #
+  elif "has to be used" in output or "has to be discarded" in output and indentLevel == 0: #
     bufferRestoreValidCode()
 
     # Save the current expression as an echo

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -202,7 +202,7 @@ proc showError(output: string) =
     message = message.multiReplace({
         "Error: expression '": "",
         " is of type '": "",
-        "' and has to be discarded": "",
+        "' and has to be used": "",
         "' and has to be used (or discarded)": ""
     })
     # Make split char to be a semicolon instead of a single-quote,
@@ -210,7 +210,6 @@ proc showError(output: string) =
     message[message.rfind("'")] = ';' # last single-quote
     let message_seq = message.split(";") # expression;type, e.g 'a';char
     let typeExpression = message_seq[1] # type, e.g. char
-
     # Ignore this colour change
     let shortcut = when defined(Windows):
             fmt"""
@@ -390,7 +389,7 @@ Help - help, help()""")
       # Roll back echoes
       bufferRestoreValidCode()
   # Maybe trying to echo value?
-  elif "has to be discarded" in output and indentLevel == 0: #
+  elif "has to be used" in output and indentLevel == 0: #
     bufferRestoreValidCode()
 
     # Save the current expression as an echo


### PR DESCRIPTION
It looks like devel has changed the old "has to be discarded" error message. This adds backwards compatibility and seems to stop tests from freezing.