### PR TITLE
#93 Fix - Unable to unindent

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -203,6 +203,7 @@ proc showError(output: string) =
         "Error: expression '": "",
         " is of type '": "",
         "' and has to be used": "",
+        "' and has to be discarded": "",
         "' and has to be used (or discarded)": ""
     })
     # Make split char to be a semicolon instead of a single-quote,
@@ -389,7 +390,7 @@ Help - help, help()""")
       # Roll back echoes
       bufferRestoreValidCode()
   # Maybe trying to echo value?
-  elif "has to be used" in output and indentLevel == 0: #
+  elif "has to be used" in output or "has to be discarded" in output and indentLevel == 0: #
     bufferRestoreValidCode()
 
     # Save the current expression as an echo

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -202,7 +202,7 @@ proc showError(output: string) =
     message = message.multiReplace({
         "Error: expression '": "",
         " is of type '": "",
-        "' and has to be discarded": "",
+        "' and has to be used": "",
         "' and has to be used (or discarded)": ""
     })
     # Make split char to be a semicolon instead of a single-quote,
@@ -210,7 +210,6 @@ proc showError(output: string) =
     message[message.rfind("'")] = ';' # last single-quote
     let message_seq = message.split(";") # expression;type, e.g 'a';char
     let typeExpression = message_seq[1] # type, e.g. char
-
     # Ignore this colour change
     let shortcut = when defined(Windows):
             fmt"""
@@ -390,7 +389,7 @@ Help - help, help()""")
       # Roll back echoes
       bufferRestoreValidCode()
   # Maybe trying to echo value?
-  elif "has to be discarded" in output and indentLevel == 0: #
+  elif "has to be used" in output and indentLevel == 0: #
     bufferRestoreValidCode()
 
     # Save the current expression as an echo

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -35,7 +35,7 @@ suite "Interface Tests":
 
     let typeLines = @[
       "type B = object",
-      "c: string",
+      "  c: string", # Have to add indents in manually for tests now
       "",
       "B"
     ]
@@ -48,6 +48,16 @@ suite "Interface Tests":
       "g"
     ]
     require getResponse(inputStream, outputStream, varLines) == """(c: "C") == type B"""
+
+
+    let ifLines = @[
+      """if true:""",
+      """  echo "TRUE"""",
+      """else:""",
+      """  echo "FALSE"""",
+      """""",
+    ]
+    require getResponse(inputStream, outputStream, ifLines) == """TRUE"""
 
     inputStream.writeLine("quit")
     inputStream.flush()


### PR DESCRIPTION
Turns out setting the prompt to the include the indentation wasn't a great idea as users can't delete it. This inserts it using noiser's preloadBuffer, so users can just backspace to reduce indent