### PR TITLE
Piping inim code will now cause inim to run said code and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * Optional Colorized output
 * Edit lines using $EDITOR (Ctrl-X)
 * Built in tools like ipython (cd(), ls(), pwd(), call()) enabled with --withTools
+* When piped a file or some code, INim will execute that code and exit
 
 ## Config
 Config is saved and loaded from `configDir / inim`.

--- a/inim.nimble
+++ b/inim.nimble
@@ -17,5 +17,7 @@ task test, "Run all tests":
   exec "mkdir -p bin"
   exec "nim c -d:NoColor -d:prompt_no_history --out:bin/inim src/inim.nim"
   exec "nim c -r -d:prompt_no_history tests/test.nim"
+  # Recompile with tty checks
+  exec "nim c -d:NoColor -d:NOTTYCHECK -d:prompt_no_history --out:bin/inim src/inim.nim"
   exec "nim c -r -d:withTools -d:prompt_no_history tests/test_commands.nim"
   exec "nim c -r -d:prompt_no_history tests/test_interface.nim"

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -77,7 +77,7 @@ proc compileCode(): auto =
   # remove redundant `--hint[source]=off`
   let compileCmd = [
       app.nim, "compile", "--run", "--verbosity=0", app.flags,
-      "--hints=off", "--hint[source]=off", "--path=./", bufferSource
+      "--hints=off", "--path=./", bufferSource
   ].join(" ")
   result = execCmdEx(compileCmd)
 

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,12 +1,12 @@
-import unittest
+import unittest, osproc, strutils
 
 import inim
 
 suite "INim Test Suite":
-  
+
   setup:
     initApp("nim", "", true)
-  
+
   teardown:
     discard
 
@@ -30,3 +30,10 @@ suite "INim Test Suite":
       hasIndentTrigger("type") == true
       hasIndentTrigger("CallbackAction* = enum ") == true
       hasIndentTrigger("Response* = ref object ") == true
+
+  test "Executes piped code from file":
+    check execCmdEx("cat tests/test_piping_file.nim | bin/inim").output.strip() == """4
+@[1, 5, 4]"""
+
+  test "Executes piped code from echo":
+    check execCmdEx("echo \"2+2\" | bin/inim").output.strip() == "4"

--- a/tests/test_piping_file.nim
+++ b/tests/test_piping_file.nim
@@ -1,0 +1,7 @@
+import strutils
+
+var b = @[1, 5]
+let c = 2+2
+echo c
+b.add(c)
+b


### PR DESCRIPTION
Fix up piping so when code is piped into INim, it will execute the code and return the output. Can be used in conjunction with the --srcFile argument to preload code and run small snippets of code against it from the command line