### PR TITLE
Fix for a block ending in an echo

### DIFF
--- a/tests/test.nim
+++ b/tests/test.nim
@@ -37,3 +37,7 @@ suite "INim Test Suite":
 
   test "Executes piped code from echo":
     check execCmdEx("echo \"2+2\" | bin/inim").output.strip() == "4"
+
+  test "Executes piped code with echo at end of block":
+    check execCmdEx("cat tests/test_piping_with_end_echo.nim | bin/inim").output.strip() == """TestVar"""
+

--- a/tests/test_piping_with_end_echo.nim
+++ b/tests/test_piping_with_end_echo.nim
@@ -1,0 +1,4 @@
+import os
+
+let a = "TestVar"
+echo a


### PR DESCRIPTION
Fixed an issue where running a block of code with an echo at the end would error. The added test file indicates the scenario where it used to fail with the following error: `Error: expression 'block:
  let a = "TestVar"
  echo [a]' has no type (or is ambiguous)
`
This checks for code blocks ending in an echo and executes them ad verbatim, under the assumption that the code block will be responsible for printing it's own output