### PR TITLE
Echo runtime output & misc cleanup

### DIFF
--- a/src/inim.nim
+++ b/src/inim.nim
@@ -207,14 +207,17 @@ proc showError(output: string, reraised: bool = false) =
 
   #### Runtime errors:
   if output.contains("Error: unhandled exception:"):
+    var lines = output.splitLines().filterIt(not it.isEmptyOrWhitespace)
+    # Print out any runtime echo messages before printing the error
+    for runtimeEchoLine in lines[0 ..< lines.len - 5]:
+      echo runtimeEchoLine
     outputFg(fgRed, true):
       # Display only the relevant lines of the stack trace
-      var lines = output.splitLines().filterIt(not it.isEmptyOrWhitespace)
 
       if not importStatement:
-        echo lines[^3]
+         echo lines[^3]
       else:
-        for line in lines[len(lines)-5 .. len(lines)-3]:
+        for line in lines[len(lines) - 5 ..< len(lines) - 1]:
           echo line
     return
 
@@ -227,13 +230,14 @@ proc showError(output: string, reraised: bool = false) =
 
   # Discard shortcut conditions
   let
-    a = currentExpression != ""
-    b = importStatement == false
-    c = previouslyIndented == false
-    d = message.contains("and has to be")
+    hasCurrentExpression = currentExpression != ""
+    noImportStatement = importStatement == false
+    notPreviousIndented = previouslyIndented == false
+    isHasToBe = message.contains("and has to be")
+    isDiscardShortcut = hasCurrentExpression and noImportStatement and notPreviousIndented and isHasToBe
 
   # Discarded shortcut, print values: nim> myvar
-  if a and b and c and d:
+  if isDiscardShortcut:
     # Following lines grabs the type from the discarded expression:
     # Remove text bloat to result into: e.g. foo'int
     message = message.multiReplace({
@@ -324,7 +328,6 @@ proc init(preload = "") =
     # instead of one-liners error
     currentExpression = "import " # Pretend it was an import for showError()
     showError(output)
-    cleanExit(1)
 
 proc hasIndentTrigger*(line: string): bool =
   if line.len == 0:

--- a/tests/test_error_output.nim
+++ b/tests/test_error_output.nim
@@ -1,0 +1,3 @@
+let a = @["a", "b", "c"]
+echo a
+echo a[^0]

--- a/tests/test_interface.nim
+++ b/tests/test_interface.nim
@@ -108,3 +108,26 @@ suite "Interface Tests":
   # Finally, delete our RCfile path
   if existsFile(testRcfilePath):
     removeFile(testRcfilePath)
+
+suite "Argument Tests":
+
+  test "Test srcFile runtime output echoes to stdout":
+    # Start our process and create links to our stdin/stdout
+    var process = startProcess(
+      "bin/inim",
+      workingDir = "",
+      args = @["--rcFilePath=" & testRcfilePath, "--showHeader=false",
+               "--withTools", "-s=tests/test_error_output.nim"],
+      options = {poDaemon}
+    )
+
+    var
+      inputStream = process.inputStream
+      outputStream = process.outputStream
+
+    # Quit straight away, but check that the runtime output of the file is
+    # printed to stdout
+    let defLines = @[
+      "quit"
+    ]
+    let resp = getResponse(inputStream, outputStream, defLines) == """@["a", "b", "c"]"""


### PR DESCRIPTION
Fix for https://github.com/inim-repl/INim/issues/30

We stripped off any runtime output previously. Now we output it.

Additionally, if a script fails to load, the error will output and the repl will continue to run