### PR TITLE
Pin noise commit to include ktCtrlX change

### DIFF
--- a/inim.nimble
+++ b/inim.nimble
@@ -11,7 +11,8 @@ bin           = @["inim"]
 
 #requires "nim >= 1.0.0" # can we remove this to imply it should work with all versions?
 requires "cligen >= 1.0.0"
-requires "noise"
+
+requires "noise >= 0.1.4"
 
 task test, "Run all tests":
   exec "mkdir -p bin"


### PR DESCRIPTION
To avoid issues with inim pulling the wrong version of noise in. 
Should be merged once  https://github.com/jangko/nim-noise/pull/11 is merged