### PR TITLE
Bumped cligen version, removed some deprecated calls

### DIFF
--- a/inim.nimble
+++ b/inim.nimble
@@ -10,7 +10,7 @@ bin           = @["inim"]
 # Dependencies
 
 #requires "nim >= 1.0.0" # can we remove this to imply it should work with all versions?
-requires "cligen >= 1.0.0"
+requires "cligen >= 1.2.0"
 
 requires "noise >= 0.1.4"
 

--- a/src/inim.nim
+++ b/src/inim.nim
@@ -190,11 +190,8 @@ proc bufferRestoreValidCode() =
 proc showError(output: string, reraised: bool = false) =
   # Determine whether last expression was to import a module
   var importStatement = false
-  try:
-    if currentExpression[0..6] == "import ":
-      importStatement = true
-  except IndexError:
-    discard
+  if currentExpression.len > 7 and currentExpression[0..6] == "import ":
+    importStatement = true
 
   #### Reraised errors. These get reraised if the statement being echoed with a type fails
   if reraised:
@@ -563,7 +560,7 @@ proc main(nim = "nim", srcFile = "", showHeader = true,
 
   discard existsorCreateDir(getConfigDir())
   let shouldCreateRc = not existsorCreateDir(rcFilePath.splitPath.head) or
-      not existsFile(rcFilePath) or createRcFile
+      not fileExists(rcFilePath) or createRcFile
   config = if shouldCreateRc: createRcFile(rcFilePath)
            else: loadRCFileConfig(rcFilePath)
 


### PR DESCRIPTION
Fix for error when building: https://github.com/inim-repl/INim/issues/108
Requires an updated version of cligen, see: https://github.com/c-blake/cligen/releases/tag/v1.2.2