### PR TITLE
Add triple quote to IndentTriggers

### DIFF
--- a/inim.nim
+++ b/inim.nim
@@ -33,7 +33,7 @@ const
   NimblePkgVersion {.strdefine.} = ""
   # endsWith
   IndentTriggers = [
-      ",", "=", ":",
+      ",", "=", ":", "\"\"\"",
       "var", "let", "const", "type", "import",
       "object", "RootObj", "enum"
   ]

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -30,6 +30,7 @@ suite "INim Test Suite":
       hasIndentTrigger("type") == true
       hasIndentTrigger("CallbackAction* = enum ") == true
       hasIndentTrigger("Response* = ref object ") == true
+      hasIndentTrigger("var s = \"\"\"") == true
 
   test "Executes piped code from file":
     check execCmdEx("cat tests/test_piping_file.nim | bin/inim").output.strip() == """4


### PR DESCRIPTION
Made this little change on my local fork, as I wanted to define a triple quote string and couldn't.

The current behaviour looks like this:
```
nim> var s = """
Error: closing """ expected, but end of file reached
```

Little drawback with this change, the closing triple quote also counts as a trigger.

Also it still won't indent if there is any text after the opening triple quote, but that would require a bit of change in the way indent triggers are checked for.