### PR TITLE
Do not determine the config directory at compile-time

### DIFF
--- a/inim.nim
+++ b/inim.nim
@@ -39,6 +39,8 @@ const
   ]
   # preloaded code into user's session
   EmbeddedCode = staticRead("inimpkg/embedded.nim")
+
+let
   ConfigDir = getConfigDir() / "inim"
   RcFilePath = ConfigDir / "inim.ini"
 
@@ -561,7 +563,7 @@ proc main(nim = "nim", srcFile = "", showHeader = true,
       )
     ).join(" ")
 
-  discard existsorCreateDir(getConfigDir())
+  discard existsorCreateDir(ConfigDir)
   let shouldCreateRc = not existsorCreateDir(rcFilePath.splitPath.head) or
       not fileExists(rcFilePath) or createRcFile
   config = if shouldCreateRc: createRcFile(rcFilePath)


### PR DESCRIPTION
INim is broken if it runs as a different user than the user it was compiled with.